### PR TITLE
[Fix] #3 - Fix f-string quotes format

### DIFF
--- a/main.py
+++ b/main.py
@@ -162,7 +162,7 @@ class BookRecord(object):
         Returns:
             str: A generated header string
         """
-        return f"<{"고유번호 / " if contain_id else ""}{"ISBN / " if contain_isbn else ""}제목 / 저자 / 출판사 / 출판년도{" / 등록날짜" if contain_register_date else ""}{" / 대출기간" if contain_borrow_info else ""}>"
+        return f"<{'고유번호 / ' if contain_id else ''}{'ISBN / ' if contain_isbn else ''}제목 / 저자 / 출판사 / 출판년도{' / 등록날짜' if contain_register_date else ''}{' / 대출기간' if contain_borrow_info else ''}>"
 
 
 class BookData(object):


### PR DESCRIPTION
### Issue
closed #3 
<br/>

### Motivation
Python f-string quotes 오류 수정
<br/>

### Key Changes
VS-Code Jupyter Server에서 f-string format 오류 발생하여 f-string 내 `"` → `'`로 수정
<br/>

<img width="800px" src="https://github.com/user-attachments/assets/701f6947-692b-4344-9d2d-8b3fd2a3ef92">
<br/>

### To Reviewer
X
<br/>

### Reference
X
<br/>