### PR TITLE
[Fix] #55 - 무결성 검사 함수에서 8번 로그 출력되는 오류 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -402,7 +402,7 @@ class BookData(object):
         
         # 8. 고유번호 중복 검사
         if len(first_elements) > len(set(first_elements)):
-            print("8 고유번호 중복")
+            if verbose: print("8 고유번호 중복")
             return False
         
         # 9. ISBN 검사


### PR DESCRIPTION
### Issue
closed #55 
<br/>

### Motivation
무결성 검사 함수에서 8번 로그 출력되는 오류 수정
<br/>

### Key Changes
8번 로그에 `if verbose:` 빠져있던 오류 수정
<br/>

```python
# 8. 고유번호 중복 검사
if len(first_elements) > len(set(first_elements)):
    if verbose: print("8 고유번호 중복")
    return False
```
<br/>

### To Reviewer
X
<br/>

### Reference
X
<br/>