### PR TITLE
[Fix] #79 - BookRecord str로 출력 시 ISBN 1자리로 출력되는 오류 수정

### DIFF
--- a/Libsystem_Main.py
+++ b/Libsystem_Main.py
@@ -143,7 +143,8 @@ class BookRecord(object):
         self.is_borrowing: bool = borrower_name is not None
         
     def __str__(self) -> str:
-        return f"{self.book_id} / {self.isbn} / {self.title} \
+        isbn_str = str(self.isbn).zfill(2)
+        return f"{self.book_id} / {isbn_str} / {self.title} \
 / {self.author} / {self.publisher} \
 / {self.published_year} / {str(self.register_date)}"
 
@@ -170,7 +171,9 @@ class BookRecord(object):
         Args:
             contain_borrow (bool, optional): Whether to include loan/return information when converting strings. Defaults to True.
         """
-        return f"{self.book_id} / {self.isbn} \
+        isbn_str = str(self.isbn).zfill(2)
+        
+        return f"{self.book_id} / {isbn_str} \
 / {self.title} / {self.author} \
 / {self.publisher} / {self.published_year} \
 / {str(self.register_date)}" \
@@ -179,7 +182,8 @@ class BookRecord(object):
 + (" *" if self.return_date < today else "")
 
     def to_record_str(self) -> str:
-        return f"{self.book_id}/{self.isbn}\
+        isbn_str = str(self.isbn).zfill(2)
+        return f"{self.book_id}/{isbn_str}\
 /{self.title}/{self.author}\
 /{self.publisher}/{self.published_year}\
 /{str(self.register_date)}" \


### PR DESCRIPTION
### Issue
closed #79 
<br/>

### Motivation
BookRecord str로 출력 시 ISBN 1자리로 출력되는 오류 수정
<br/>

### Key Changes
BookRecord 내에서 ISBN이 1자리 수인 경우 1자리만 출력되는 문제 해결
`str.zfill()`을 사용해 1자리일 경우 0을 채워 출력
<br/>

```python
def __str__(self) -> str:
        isbn_str = str(self.isbn).zfill(2)
        return f"{self.book_id} / {isbn_str} / {self.title} \
/ {self.author} / {self.publisher} \
/ {self.published_year} / {str(self.register_date)}"
```
<br/>

### To Reviewer
X
<br/>

### Reference
x
<br/>