### PR TITLE
[Fix] #158 - 책 레코드 출력 시 반납된 데이터 제외하고 출력하도록 수정

### DIFF
--- a/Libsystem_Main2.py
+++ b/Libsystem_Main2.py
@@ -1371,7 +1371,7 @@ class DataManager(object):
         # find borrow info
         borrow_data = None
         if include_borrow:
-            for borrow in self.borrow_table:
+            for borrow in self.borrow_table and borrow.actual_return_date is None: # 반납이 완료된 대출 정보는 제외
                 if borrow.book_id == book_id:
                     borrow_data = borrow
                     break


### PR DESCRIPTION
### Issue
closed #158 
<br/>

### Motivation
책 레코드 출력 시 반납된 데이터 제외하고 출력하도록 수정
<br/>

### Key Changes
대출 정보 출력 시 실제반납날짜가 존재하는 경우 제외
<br/>

```python
# find borrow info
borrow_data = None
if include_borrow:
    for borrow in self.borrow_table and borrow.actual_return_date is None: # 반납이 완료된 대출 정보는 제외
        if borrow.book_id == book_id:
            borrow_data = borrow
            break
```
<br/>

### To Reviewer
X
<br/>

### Reference
X
<br/>