### PR TITLE
[Fix] #163 - data 디렉토리 없는 경우 생성하도록 수정

### DIFF
--- a/Libsystem_Main2.py
+++ b/Libsystem_Main2.py
@@ -267,6 +267,11 @@ class DataManager(object):
 
         if verbose: print("="*10, "Start Reading Data Files", "="*10)
         
+        # 경로에 "data" 폴더가 없으면 생성
+        data_folder_path = opj(self.file_path, "data")
+        if not os.path.exists(data_folder_path):
+            os.makedirs(data_folder_path)
+        
         # ---------- 1. Publisher Data ----------
          # 파일이 존재하지 않으면 생성
         if not os.path.exists(opj(self.file_path, "data", "Libsystem_Data_Publisher.txt")):


### PR DESCRIPTION
### Issue
closed #163 
<br/>

### Motivation
data 디렉토리 없는 경우 생성하도록 수정
<br/>

### Key Changes
경로에 `data` 폴더가 있는지 검사한 후 없으면 생성
<br/>

```python
# 데이터 파일 읽기
def read_data_files(self, sep: str="/", verbose=True) -> tuple[bool, str]:

    if verbose: print("="*10, "Start Reading Data Files", "="*10)
    
    # 경로에 "data" 폴더가 없으면 생성
    data_folder_path = opj(self.file_path, "data")
    if not os.path.exists(data_folder_path):
        os.makedirs(data_folder_path)
```
<br/>

### To Reviewer
X
<br/>

### Reference
X
<br/>