### PR TITLE
[Fix] #188 - 동명이인 아닌 저자는 식별번호 출력 안하도록 수정

### DIFF
--- a/Libsystem_Main2.py
+++ b/Libsystem_Main2.py
@@ -1813,7 +1813,11 @@ class DataManager(object):
         for author_id in author_ids:
             author = self.search_author_by_id(author_id)
             if author:
-                names.append(f"{author.name} #{author.author_id}")
+                # 동명 이인 있는 경우 식별번호를 붙여줌
+                if len(self.search_author_by_name(author.name)) > 1:
+                    names.append(f"{author.name} #{author.author_id}")
+                else:
+                    names.append(author.name)
                 
         return " & ".join(names)
 


### PR DESCRIPTION
### Issue
closed #188 
<br/>

### Motivation
동명이인 아닌 저자는 식별번호 출력 안하도록 수정
<br/>

### Key Changes
- 동명이인인지 체크하고, 아니면 이름만 출력하도록 변경
<br/>

```python
# 저자 식별번호로 이름 #식별번호 형태로 반환
def convert_author_ids_to_name_id(self, author_ids: list[int]) → str:

    names = []
    
    # 저자 없는 경우 "-" 반환
    if len(author_ids) == 0:
        return "-"
    
    for author_id in author_ids:
        author = self.search_author_by_id(author_id)
        if author:
            # 동명 이인 있는 경우 식별번호를 붙여줌
            if len(self.search_author_by_name(author.name)) > 1:
                names.append(f"{author.name} #{author.author_id}")
            else:
                names.append(author.name)
            
    return " & ".join(names)```
<br/>

### To Reviewer
x
<br/>

### Reference
x
<br/>