### PR TITLE
[Fix] #192 - Book 데이터 파일이 비어있는 경우 오류 발생 수정

### DIFF
--- a/Libsystem_Main2.py
+++ b/Libsystem_Main2.py
@@ -343,7 +343,12 @@ class DataManager(object):
         if os.stat(self.file_path).st_size == 0:
             with open(opj(self.file_path, "data", "Libsystem_Data_Book.txt"), "w", encoding='utf-8') as f:
                 f.write("0\n")
-            
+                
+        with open(opj(self.file_path, "data", "Libsystem_Data_Book.txt"), "r",encoding='utf-8') as rf:
+            lines = rf.read()
+            if len(lines) == 0:
+                with open(opj(self.file_path, "data", "Libsystem_Data_Book.txt"), "w", encoding='utf-8') as wf:
+                    wf.write("0\n")
         
         # 무결성 검사(데이터가 올바르지 않을경우 파일명 변경(Libsystem_Data_{테이블명}-yyyyMMdd_hhmmss.bak) 후 새 Libsystem_Data_Book.txt 파일 생성)
         # yyyyMMdd-hhmmss는 컴퓨터 운영체제 시스템 시간을 기준으로 함


### PR DESCRIPTION
### Issue
closed #192
<br/>

### Motivation
Book 데이터 파일이 비어있는 경우 오류 발생 수정
<br/>

### Key Changes
파일이 존재는 하는데 비어있는 (메타 데이터 제외) 경우 오류 발생
아래와 같이 메타 데이터는 존재해서 파일 크기는 0이 아닌데 읽은 데이터 길이가 0인 경우 예외처리 추가
<br/>

```python
with open(opj(self.file_path, "data", "Libsystem_Data_Book.txt"), "r",encoding='utf-8') as rf:
    lines = rf.read()
    if len(lines) == 0:
        with open(opj(self.file_path, "data", "Libsystem_Data_Book.txt"), "w", encoding='utf-8') as wf:
            wf.write("0\n")
```
<br/>

### To Reviewer
확인 부탁드립니다!
<br/>

### Reference
X
<br/>